### PR TITLE
Fix compilation bug when using current versions of Flutter/flame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [next]
+
+* Fix compilation bug when using current versions of Flutter/flame
+
 ## 0.0.1
 
 * TODO: Describe initial release.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.android.tools.build:gradle:3.4.1'
     }
 }
 
@@ -22,7 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
 
     defaultConfig {
         minSdkVersion 16

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -69,3 +69,6 @@ build/
 !**/ios/**/default.pbxuser
 !**/ios/**/default.perspectivev3
 !/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages
+
+.flutter-plugins-dependencies
+flutter_export_environment.sh


### PR DESCRIPTION
On BGUG current master I can't build for android because of this.